### PR TITLE
Full support for bare and quoted keys

### DIFF
--- a/TOML-example.toml
+++ b/TOML-example.toml
@@ -103,3 +103,12 @@ a=[ 1, 2.0 ] # note: this is NOT ok
 [[Array.of.table]]
 
 [table]
+
+[table]
+key = "value"
+bare_key = "value"
+bare-key = "value"
+
+"127.0.0.1" = "value"
+"character encoding" = "value"
+"ʎǝʞ" = "value"

--- a/TOML.YAML-tmLanguage
+++ b/TOML.YAML-tmLanguage
@@ -65,7 +65,7 @@ repository:
     - name: invalid.deprecated.noValueGiven.toml
       match: ^(\s*[A-Za-z_][A-Za-z0-9_]*\s*=)(?=\s*$)
       comment: Assignments without value are unusual
-    - begin: '^\s*([A-Za-z_][A-Za-z0-9_]*)\s*(=)\s*'
+    - begin: '^\s*([A-Za-z_-][A-Za-z0-9_-]*|".+")\s*(=)\s*'
       end: ($|(?==))
       beginCaptures:
         '1': {name: keyword.key.toml}


### PR DESCRIPTION
Support for keys like `bare-key` and `"ʎǝʞ"`.
