### PR TITLE
Support toggling comment lines (got lost in a trail of github forks?)

### DIFF
--- a/Comments.YAML-tmPreferences
+++ b/Comments.YAML-tmPreferences
@@ -1,0 +1,7 @@
+name: Comments
+scope: source.toml
+settings:
+  shellVariables:
+    - name: TM_COMMENT_START
+      value: "# "
+uuid: 1756cf6c-a968-4b8d-91ce-89478b6ab636

--- a/Comments.tmPreferences
+++ b/Comments.tmPreferences
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Comments</string>
+	<key>scope</key>
+	<string>source.toml</string>
+	<key>settings</key>
+	<dict>
+		<key>shellVariables</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START</string>
+				<key>value</key>
+				<string># </string>
+			</dict>
+		</array>
+	</dict>
+	<key>uuid</key>
+	<string>1756cf6c-a968-4b8d-91ce-89478b6ab636</string>
+</dict>
+</plist>


### PR DESCRIPTION
This capability was in the original package, but that's not the package in package manager, so let's add that back.
