### PR TITLE
Added support for dashes in table names

### DIFF
--- a/TOML.YAML-tmLanguage
+++ b/TOML.YAML-tmLanguage
@@ -28,12 +28,12 @@ repository:
       end: (?=^\s*\[?\[.*\]\]?)
       comment: "non-empty etc. like tables, see below!"
     - name: meta.tag.table.array.toml
-      begin: ^\s*(\[\[)([A-Za-z_][A-Za-z0-9_\.-]*)(\]\])\s*
+      begin: ^\s*(\[\[)([A-Za-z_\-][A-Za-z0-9_\-\.]*)(\]\])\s*
       beginCaptures:
         '1': {name: punctuation.definition.table.array.toml}
         '2': {name: entity.other.attribute-name.table.array.toml}
         '3': {name: punctuation.definition.table.array.toml}
-      end: (?=^\s*\[?\[[A-Za-z_][A-Za-z0-9_\.-]*\]\]?)
+      end: (?=^\s*\[?\[[A-Za-z_\-][A-Za-z0-9_\-\.]*\]\]?)
       comment: A named TOML-Table-Array
       patterns:
       - include: '#comments'
@@ -45,12 +45,12 @@ repository:
       end: (?=^\s*\[?\[.*\]\]?)
       comment: "Each table name segment must be non-empty, must not contain the characters '[', ']' or '#' and is delimited by a '.'.  Tables \"appear in square brackets *on a line by themselves*\""
     - name: meta.tag.table.toml
-      begin: ^\s*(\[)([A-Za-z_][A-Za-z0-9_\.-]*)(\])\s*
+      begin: ^\s*(\[)([A-Za-z_\-][A-Za-z0-9_\-\.]*)(\])\s*
       beginCaptures:
         '1': {name: punctuation.definition.table.toml}
         '2': {name: entity.other.attribute-name.table.toml}
         '3': {name: punctuation.definition.table.toml}
-      end: (?=^\s*\[?\[[A-Za-z_][A-Za-z0-9_\.-]*\]\]?)
+      end: (?=^\s*\[?\[[A-Za-z_\-][A-Za-z0-9_\-\.]*\]\]?)
       comment: A named TOML-Table
       patterns:
       - include: '#comments'
@@ -63,9 +63,9 @@ repository:
       match: ^(\s*=.*)$
       comment: Assignments without key are invalid
     - name: invalid.deprecated.noValueGiven.toml
-      match: ^(\s*[A-Za-z_][A-Za-z0-9_]*\s*=)(?=\s*$)
+      match: ^(\s*[A-Za-z_\-][A-Za-z0-9_\-]*\s*=)(?=\s*$)
       comment: Assignments without value are unusual
-    - begin: '^\s*([A-Za-z_-][A-Za-z0-9_\-]*|".+")\s*(=)\s*'
+    - begin: '^\s*([A-Za-z_-][A-Za-z0-9_-]*|".+")\s*(=)\s*'
       end: ($|(?==))
       beginCaptures:
         '1': {name: keyword.key.toml}

--- a/TOML.tmLanguage
+++ b/TOML.tmLanguage
@@ -215,7 +215,7 @@
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>^\s*([A-Za-z_-][A-Za-z0-9_\-]*|".+")\s*(=)\s*</string>
+					<string>^\s*([A-Za-z_][A-Za-z0-9_]*)\s*(=)\s*</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -316,7 +316,7 @@
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>^\s*(\[\[)([A-Za-z_][A-Za-z0-9_\.-]*)(\]\])\s*</string>
+					<string>^\s*(\[\[)([A-Za-z_][A-Za-z0-9_\.]*)(\]\])\s*</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -338,7 +338,7 @@
 					<key>comment</key>
 					<string>A named TOML-Table-Array</string>
 					<key>end</key>
-					<string>(?=^\s*\[?\[[A-Za-z_][A-Za-z0-9_\.-]*\]\]?)</string>
+					<string>(?=^\s*\[?\[[A-Za-z_][A-Za-z0-9_\.]*\]\]?)</string>
 					<key>name</key>
 					<string>meta.tag.table.array.toml</string>
 					<key>patterns</key>
@@ -369,7 +369,7 @@
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>^\s*(\[)([A-Za-z_][A-Za-z0-9_\.-]*)(\])\s*</string>
+					<string>^\s*(\[)([A-Za-z_][A-Za-z0-9_\.]*)(\])\s*</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -391,7 +391,7 @@
 					<key>comment</key>
 					<string>A named TOML-Table</string>
 					<key>end</key>
-					<string>(?=^\s*\[?\[[A-Za-z_][A-Za-z0-9_\.-]*\]\]?)</string>
+					<string>(?=^\s*\[?\[[A-Za-z_][A-Za-z0-9_\.]*\]\]?)</string>
 					<key>name</key>
 					<string>meta.tag.table.toml</string>
 					<key>patterns</key>


### PR DESCRIPTION
Per version 0.4.0 of the TOML standard, dashes are a valid part of table names in TOML files. This updates the appropriate regexes to correctly highlight table names that use dashes.
